### PR TITLE
유저는 검색 결과를 스크롤해서 데이터가 존재하는 한 무한으로 조회할 수 있다. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^3.2.5",
-        "msw": "^0.44.0",
+        "msw": "^0.44.1",
         "prettier": "^2.7.1",
         "react-app-rewired": "^2.2.1",
         "webpack": "^5.73.0"
@@ -23676,9 +23676,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msw": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.44.0.tgz",
-      "integrity": "sha512-LLXfLos7JwzI1bfh0cBIKffXfyISezsMXALS2M1uq56pn1UhGVtyz8OaAguiJFxkirqn+S6e0GcKuGVDwZG1dg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.44.1.tgz",
+      "integrity": "sha512-QhTZJQCCv+y4G5l2dLz+2N4K+wWEiz+HfvW6o3ZznDDHbKhQyYmzymU7bWVXXhLbUw7xgxPRxxm1XsYVb6WR7Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -50468,9 +50468,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msw": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.44.0.tgz",
-      "integrity": "sha512-LLXfLos7JwzI1bfh0cBIKffXfyISezsMXALS2M1uq56pn1UhGVtyz8OaAguiJFxkirqn+S6e0GcKuGVDwZG1dg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.44.1.tgz",
+      "integrity": "sha512-QhTZJQCCv+y4G5l2dLz+2N4K+wWEiz+HfvW6o3ZznDDHbKhQyYmzymU7bWVXXhLbUw7xgxPRxxm1XsYVb6WR7Q==",
       "dev": true,
       "requires": {
         "@mswjs/cookies": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.2.5",
-    "msw": "^0.44.0",
+    "msw": "^0.44.1",
     "prettier": "^2.7.1",
     "react-app-rewired": "^2.2.1",
     "webpack": "^5.73.0"

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.44.0).
+ * Mock Service Worker (0.44.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.
@@ -155,8 +155,7 @@ async function handleRequest(event, requestId) {
           ok: clonedResponse.ok,
           status: clonedResponse.status,
           statusText: clonedResponse.statusText,
-          body:
-            clonedResponse.body === null ? null : await clonedResponse.text(),
+          body: clonedResponse.body === null ? null : await clonedResponse.text(),
           headers: Object.fromEntries(clonedResponse.headers.entries()),
           redirected: clonedResponse.redirected,
         },
@@ -234,9 +233,7 @@ async function getResponse(event, client, requestId) {
   // Create a communication channel scoped to the current request.
   // This way events can be exchanged outside of the worker's global
   // "message" event listener (i.e. abstracted into functions).
-  const operationChannel = new BroadcastChannel(
-    `msw-response-stream-${requestId}`,
-  );
+  const operationChannel = new BroadcastChannel(`msw-response-stream-${requestId}`);
 
   // Notify the client that a request has been intercepted.
   const clientMessage = await sendToClient(client, {

--- a/src/components/ProductList/Product.tsx
+++ b/src/components/ProductList/Product.tsx
@@ -1,55 +1,64 @@
-import { SyntheticEvent } from 'react';
+import { forwardRef, SyntheticEvent, useImperativeHandle, useRef } from 'react';
 
 import { Images } from '@assets/images';
 import * as S from '@components/ProductList/ProductList.style';
 import { ProductType } from '@data/products';
 import { addComma } from '@utils/addComma';
 
-const Product = ({
-  goodsName,
-  price,
-  brandName,
-  imageUrl,
-  linkUrl,
-  brandLinkUrl,
-  normalPrice,
-  isSale,
-  saleRate,
-  isSoldOut,
-  isExclusive,
-}: ProductType) => {
-  const handleImageError = (event: SyntheticEvent<HTMLImageElement>) => {
-    const image = event.target as HTMLImageElement;
-    image.src = Images.DefaultImage;
-    image.style.objectFit = 'fill';
-  };
+const Product = forwardRef<HTMLLIElement, ProductType>(
+  (
+    {
+      goodsName,
+      price,
+      brandName,
+      imageUrl,
+      linkUrl,
+      brandLinkUrl,
+      normalPrice,
+      isSale,
+      saleRate,
+      isSoldOut,
+      isExclusive,
+    },
+    ref?,
+  ) => {
+    const productRef = useRef<HTMLLIElement>(null);
 
-  return (
-    <S.Product>
-      <S.ImageContainer href={linkUrl}>
-        <S.Image src={imageUrl} alt={goodsName} onError={handleImageError} />
-        {isSoldOut && <S.SoldOutLayer>SOLD OUT</S.SoldOutLayer>}
-      </S.ImageContainer>
-      <S.ProductInfo>
-        {isExclusive && <S.Label>단독</S.Label>}
-        <S.Brand href={brandLinkUrl}>{brandName}</S.Brand>
-        <S.Name href={linkUrl}>
-          <h2>{goodsName}</h2>
-        </S.Name>
-        {isSale ? (
-          <>
-            <S.PriceContainer>
-              <S.FinalPrice>{addComma(price)}원</S.FinalPrice>
-              <S.SaleRate>{saleRate}%</S.SaleRate>
-            </S.PriceContainer>
-            <S.Price>{addComma(normalPrice)}원</S.Price>
-          </>
-        ) : (
-          <S.FinalPrice>{addComma(price)}원</S.FinalPrice>
-        )}
-      </S.ProductInfo>
-    </S.Product>
-  );
-};
+    const handleImageError = (event: SyntheticEvent<HTMLImageElement>) => {
+      const image = event.target as HTMLImageElement;
+      image.src = Images.DefaultImage;
+      image.style.objectFit = 'fill';
+    };
+
+    useImperativeHandle(ref, () => productRef.current as HTMLLIElement, [ref]);
+
+    return (
+      <S.Product ref={productRef}>
+        <S.ImageContainer href={linkUrl}>
+          <S.Image src={imageUrl} alt={goodsName} onError={handleImageError} />
+          {isSoldOut && <S.SoldOutLayer>SOLD OUT</S.SoldOutLayer>}
+        </S.ImageContainer>
+        <S.ProductInfo>
+          {isExclusive && <S.Label>단독</S.Label>}
+          <S.Brand href={brandLinkUrl}>{brandName}</S.Brand>
+          <S.Name href={linkUrl}>
+            <h2>{goodsName}</h2>
+          </S.Name>
+          {isSale ? (
+            <>
+              <S.PriceContainer>
+                <S.FinalPrice>{addComma(price)}원</S.FinalPrice>
+                <S.SaleRate>{saleRate}%</S.SaleRate>
+              </S.PriceContainer>
+              <S.Price>{addComma(normalPrice)}원</S.Price>
+            </>
+          ) : (
+            <S.FinalPrice>{addComma(price)}원</S.FinalPrice>
+          )}
+        </S.ProductInfo>
+      </S.Product>
+    );
+  },
+);
 
 export default Product;

--- a/src/components/ProductList/ProductList.style.ts
+++ b/src/components/ProductList/ProductList.style.ts
@@ -2,7 +2,13 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
+  flex-direction: column;
   flex-grow: 1;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
 export const ProductList = styled.ul`
@@ -31,6 +37,11 @@ export const ImageContainer = styled.a`
   display: block;
   width: 100%;
   height: 60vw;
+`;
+
+export const LoadingSpinnerContainer = styled.div`
+  width: 100%;
+  height: 100px;
 `;
 
 export const Product = styled.li`

--- a/src/components/ProductList/ProductList.style.ts
+++ b/src/components/ProductList/ProductList.style.ts
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 
-export const Container = styled.ul`
+export const Container = styled.div`
+  display: flex;
+  flex-grow: 1;
+`;
+
+export const ProductList = styled.ul`
   display: flex;
   flex-wrap: wrap;
 `;
@@ -8,6 +13,16 @@ export const Container = styled.ul`
 export const Separator = styled.div`
   height: 10px;
   background-color: ${({ theme }) => theme.colors.grey5};
+`;
+
+export const NoSearchResult = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+  color: ${({ theme }) => theme.colors.grey2};
+  font-size: ${({ theme }) => theme.fontSizes.medium};
 `;
 
 export const ImageContainer = styled.a`

--- a/src/components/ProductList/ProductList.style.ts
+++ b/src/components/ProductList/ProductList.style.ts
@@ -8,6 +8,7 @@ export const Container = styled.div`
 export const ProductList = styled.ul`
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 `;
 
 export const Separator = styled.div`

--- a/src/components/ProductList/index.tsx
+++ b/src/components/ProductList/index.tsx
@@ -1,49 +1,25 @@
-import { useRecoilValue } from 'recoil';
-
 import Product from '@components/ProductList/Product';
 import * as S from '@components/ProductList/ProductList.style';
 import Icon from '@components/common/Icon';
 import { ICON_NAME, ICON_SIZE } from '@components/common/Icon/constants';
-import { products } from '@data';
-import { activeFilterState } from '@store/filter';
+import useFilterData from '@hooks/useFilterData';
+import { useProductQuery } from '@query/product';
 
 const ProductList = () => {
-  const { filter, search } = useRecoilValue(activeFilterState);
+  const { data } = useProductQuery();
 
-  const filteredData = () => {
-    if (!search.length && !filter.length)
-      return products[0].list.filter((product) => !product.isSoldOut);
+  const filteredData = useFilterData(data);
 
-    return products[0].list.filter((product) => {
-      const isFilterValueExist = filter.length
-        ? filter.every((value) => {
-            if (value === 'isSoldOut') return true;
-            return product[value];
-          })
-        : true;
-
-      const isSoldOut = !filter.includes('isSoldOut') ? !product.isSoldOut : true;
-
-      const isSearchValueExist = search.length
-        ? search.every(
-            (value) => product.goodsName.includes(value) || product.brandName.includes(value),
-          )
-        : true;
-
-      return isFilterValueExist && isSoldOut && isSearchValueExist;
-    });
-  };
-
-  return (
+  return filteredData ? (
     <>
       <S.Separator />
       <S.Container>
         <S.ProductList>
-          {filteredData().map((product) => (
-            <Product key={product.goodsNo} {...product} />
-          ))}
+          {filteredData.map((product) => {
+            return <Product key={product.goodsNo} {...product} />;
+          })}
         </S.ProductList>
-        {!filteredData().length && (
+        {!filteredData.length && (
           <S.NoSearchResult>
             <Icon iconName={ICON_NAME.EMPTY} iconSize={ICON_SIZE.X_LARGE} />
             검색 결과 없음
@@ -51,7 +27,7 @@ const ProductList = () => {
         )}
       </S.Container>
     </>
-  );
+  ) : null;
 };
 
 export default ProductList;

--- a/src/components/ProductList/index.tsx
+++ b/src/components/ProductList/index.tsx
@@ -2,6 +2,8 @@ import { useRecoilValue } from 'recoil';
 
 import Product from '@components/ProductList/Product';
 import * as S from '@components/ProductList/ProductList.style';
+import Icon from '@components/common/Icon';
+import { ICON_NAME, ICON_SIZE } from '@components/common/Icon/constants';
 import { products } from '@data';
 import { activeFilterState } from '@store/filter';
 
@@ -36,9 +38,17 @@ const ProductList = () => {
     <>
       <S.Separator />
       <S.Container>
-        {filteredData().map((product) => (
-          <Product key={product.goodsNo} {...product} />
-        ))}
+        <S.ProductList>
+          {filteredData().map((product) => (
+            <Product key={product.goodsNo} {...product} />
+          ))}
+        </S.ProductList>
+        {!filteredData().length && (
+          <S.NoSearchResult>
+            <Icon iconName={ICON_NAME.EMPTY} iconSize={ICON_SIZE.X_LARGE} />
+            검색 결과 없음
+          </S.NoSearchResult>
+        )}
       </S.Container>
     </>
   );

--- a/src/components/ProductList/index.tsx
+++ b/src/components/ProductList/index.tsx
@@ -5,31 +5,25 @@ import * as S from '@components/ProductList/ProductList.style';
 import Icon from '@components/common/Icon';
 import { ICON_NAME, ICON_SIZE } from '@components/common/Icon/constants';
 import useFilterData from '@hooks/useFilterData';
+import useObserver from '@hooks/useObserver';
 import { useProductQuery } from '@query/product';
 
 const ProductList = () => {
   const productRef = useRef<HTMLLIElement>(null);
+
+  const [observe, disconnect] = useObserver({
+    ref: productRef,
+    callback: () => hasNextPage && fetchNextPage(),
+    threshold: 0.5,
+  });
+
   const { data, hasNextPage, fetchNextPage } = useProductQuery();
 
   const filteredData = useFilterData(data);
 
-  const handleIntersection = (entries: IntersectionObserverEntry[]) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        hasNextPage && fetchNextPage();
-      }
-    });
-  };
-
   useEffect(() => {
-    let observer: IntersectionObserver;
-    if (productRef.current) {
-      observer = new IntersectionObserver(handleIntersection, {
-        threshold: 0.5,
-      });
-      observer.observe(productRef.current);
-    }
-    return () => observer && observer.disconnect();
+    observe();
+    return () => disconnect();
   }, [filteredData]);
 
   return filteredData ? (

--- a/src/components/ProductList/index.tsx
+++ b/src/components/ProductList/index.tsx
@@ -4,6 +4,7 @@ import Product from '@components/ProductList/Product';
 import * as S from '@components/ProductList/ProductList.style';
 import Icon from '@components/common/Icon';
 import { ICON_NAME, ICON_SIZE } from '@components/common/Icon/constants';
+import LoadingSpinner from '@components/common/LoadingSpinner';
 import useFilterData from '@hooks/useFilterData';
 import useObserver from '@hooks/useObserver';
 import { useProductQuery } from '@query/product';
@@ -17,7 +18,7 @@ const ProductList = () => {
     threshold: 0.5,
   });
 
-  const { data, hasNextPage, fetchNextPage } = useProductQuery();
+  const { isLoading, data, hasNextPage, fetchNextPage } = useProductQuery();
 
   const filteredData = useFilterData(data);
 
@@ -26,27 +27,31 @@ const ProductList = () => {
     return () => disconnect();
   }, [filteredData]);
 
-  return filteredData ? (
-    <>
+  return !isLoading ? (
+    <S.Container>
       <S.Separator />
-      <S.Container>
+      <S.Wrapper>
         <S.ProductList>
-          {filteredData.map((product, index) => {
+          {filteredData?.map((product, index) => {
             if (index === filteredData.length - 1) {
               return <Product key={`${product.goodsNo}${index}`} {...product} ref={productRef} />;
             }
             return <Product key={`${product.goodsNo}${index}`} {...product} />;
           })}
         </S.ProductList>
-        {!filteredData.length && (
+        {!filteredData?.length && (
           <S.NoSearchResult>
             <Icon iconName={ICON_NAME.EMPTY} iconSize={ICON_SIZE.X_LARGE} />
             검색 결과 없음
           </S.NoSearchResult>
         )}
-      </S.Container>
-    </>
-  ) : null;
+      </S.Wrapper>
+    </S.Container>
+  ) : (
+    <S.LoadingSpinnerContainer>
+      <LoadingSpinner />
+    </S.LoadingSpinnerContainer>
+  );
 };
 
 export default ProductList;

--- a/src/components/common/Icon/Icon.style.ts
+++ b/src/components/common/Icon/Icon.style.ts
@@ -39,5 +39,7 @@ const sizeStyles = css<StyledIconProps>`
 
 export const Icon = styled(SVG)<StyledIconProps>`
   flex-shrink: 0;
+
+  /* 사이즈 */
   ${sizeStyles}
 `;

--- a/src/components/common/LoadingSpinner/LoadingSpinner.stories.tsx
+++ b/src/components/common/LoadingSpinner/LoadingSpinner.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import LoadingSpinner from '@components/common/LoadingSpinner';
+import * as S from '@components/common/LoadingSpinner/LoadingSpinner.style';
+import { SPINNER_SIZE } from '@components/common/LoadingSpinner/constants';
+
+export default {
+  title: 'Common/LoadingSpinner',
+  component: LoadingSpinner,
+  args: {
+    spinnerSize: SPINNER_SIZE.SMALL,
+  },
+  argTypes: {
+    spinnerSize: {
+      control: {
+        type: 'radio',
+      },
+      options: [...Object.values(SPINNER_SIZE)],
+    },
+  },
+} as ComponentMeta<typeof LoadingSpinner>;
+
+export const Default: ComponentStory<typeof LoadingSpinner> = (args) => (
+  <S.StoryContainer>
+    <LoadingSpinner {...args} />
+  </S.StoryContainer>
+);

--- a/src/components/common/LoadingSpinner/LoadingSpinner.style.ts
+++ b/src/components/common/LoadingSpinner/LoadingSpinner.style.ts
@@ -1,0 +1,68 @@
+import styled, { css, keyframes } from 'styled-components';
+
+import { SPINNER_SIZE } from '@components/common/LoadingSpinner/constants';
+
+type StyledSpinnerProps = {
+  size: string;
+};
+
+const sizeStyles = css<StyledSpinnerProps>`
+  ${({ size }) =>
+    size === SPINNER_SIZE.SMALL &&
+    css`
+      width: 1rem;
+      height: 1rem;
+      border-width: 2px;
+      margin-top: -0.5rem;
+      margin-left: -0.5rem;
+    `}
+
+  ${({ size }) =>
+    size === SPINNER_SIZE.MEDIUM &&
+    css`
+      width: 2rem;
+      height: 2rem;
+      border-width: 3px;
+      margin-top: -1rem;
+      margin-left: -1rem;
+    `}
+
+  ${({ size }) =>
+    size === SPINNER_SIZE.LARGE &&
+    css`
+      width: 3rem;
+      height: 3rem;
+      border-width: 4px;
+      margin-top: -1.5rem;
+      margin-left: -1.5rem;
+    `}
+`;
+
+export const StoryContainer = styled.div`
+  position: relative;
+  width: 300px;
+  height: 300px;
+  border: 1px solid ${({ theme }) => theme.colors.grey3};
+`;
+
+const spinnerAnimation = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const LoadingSpinner = styled.div<StyledSpinnerProps>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border: 2px solid ${({ theme }) => theme.colors.grey3};
+  border-radius: 50%;
+  border-top-color: ${({ theme }) => theme.colors.blue};
+  animation: ${spinnerAnimation} 800ms ease infinite;
+
+  /* 사이즈 */
+  ${sizeStyles};
+`;

--- a/src/components/common/LoadingSpinner/constants.ts
+++ b/src/components/common/LoadingSpinner/constants.ts
@@ -1,0 +1,5 @@
+export const SPINNER_SIZE = {
+  SMALL: 'SMALL',
+  MEDIUM: 'MEDIUM',
+  LARGE: 'LARGE',
+} as const;

--- a/src/components/common/LoadingSpinner/index.tsx
+++ b/src/components/common/LoadingSpinner/index.tsx
@@ -1,0 +1,12 @@
+import * as S from '@components/common/LoadingSpinner/LoadingSpinner.style';
+import { SPINNER_SIZE } from '@components/common/LoadingSpinner/constants';
+
+interface LoadingSpinnerPropsType {
+  spinnerSize?: string;
+}
+
+const LoadingSpinner = ({ spinnerSize = SPINNER_SIZE.SMALL }: LoadingSpinnerPropsType) => {
+  return <S.LoadingSpinner size={spinnerSize} />;
+};
+
+export default LoadingSpinner;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,1 @@
+export const PRODUCT_API = '/api/products';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { PRODUCT_API } from '@constants/api';

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -142,6 +142,7 @@ export const products = [
         isExclusive: true,
       },
     ],
+    isLast: false,
   },
   {
     list: [
@@ -286,6 +287,7 @@ export const products = [
         isExclusive: false,
       },
     ],
+    isLast: false,
   },
   {
     list: [
@@ -430,6 +432,7 @@ export const products = [
         isExclusive: false,
       },
     ],
+    isLast: false,
   },
   {
     list: [
@@ -574,6 +577,7 @@ export const products = [
         isExclusive: false,
       },
     ],
+    isLast: true,
   },
 ];
 

--- a/src/hooks/useFilterData.ts
+++ b/src/hooks/useFilterData.ts
@@ -1,0 +1,42 @@
+import { InfiniteData } from 'react-query';
+import { useRecoilValue } from 'recoil';
+
+import { FetchProductsReturnType } from '@query/product';
+import { activeFilterState } from '@store/filter';
+
+const useFilterData = (data: InfiniteData<FetchProductsReturnType> | undefined) => {
+  const { filter, search } = useRecoilValue(activeFilterState);
+
+  const filterData = () => {
+    if (!data) return data;
+
+    if (!search.length && !filter.length) {
+      return data.pages.map(({ list }) => list.filter((product) => !product.isSoldOut));
+    }
+
+    return data.pages.map(({ list }) => {
+      return list.filter((product) => {
+        const isFilterValueExist = filter.length
+          ? filter.every((value) => {
+              if (value === 'isSoldOut') return true;
+              return product[value];
+            })
+          : true;
+
+        const isSoldOut = !filter.includes('isSoldOut') ? !product.isSoldOut : true;
+
+        const isSearchValueExist = search.length
+          ? search.every(
+              (value) => product.goodsName.includes(value) || product.brandName.includes(value),
+            )
+          : true;
+
+        return isFilterValueExist && isSoldOut && isSearchValueExist;
+      });
+    });
+  };
+
+  return filterData()?.flat(2);
+};
+
+export default useFilterData;

--- a/src/hooks/useObserver.ts
+++ b/src/hooks/useObserver.ts
@@ -1,0 +1,44 @@
+import { RefObject } from 'react';
+
+interface useObserverPropsType<T> {
+  ref: RefObject<T>;
+  callback: () => void;
+  threshold: number;
+}
+
+type useObserverReturnType = [() => void, () => void];
+
+const useObserver = <T extends Element>({
+  ref,
+  callback,
+  threshold,
+}: useObserverPropsType<T>): useObserverReturnType => {
+  let observer: IntersectionObserver;
+
+  const handleIntersection = (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver,
+  ) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        callback();
+        observer.disconnect();
+      }
+    });
+  };
+
+  const observe = () => {
+    if (ref.current) {
+      observer = new IntersectionObserver(handleIntersection, {
+        threshold,
+      });
+      observer.observe(ref.current);
+    }
+  };
+
+  const disconnect = () => observer && observer.disconnect();
+
+  return [observe, disconnect];
+};
+
+export default useObserver;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,14 +8,15 @@ import { ThemeProvider } from 'styled-components';
 
 import GlobalStyle from '@assets/styles/GlobalStyle';
 import { theme } from '@assets/styles/theme';
+import { worker } from '@mocks/browser';
 
 import App from './App';
 
+worker.start();
+
 export const queryClient = new QueryClient();
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
 root.render(
   <React.StrictMode>

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw';
+
+import { handlers } from '@mocks/handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,0 +1,11 @@
+import { rest } from 'msw';
+
+import { PRODUCT_API } from '@constants';
+import { products } from '@data';
+
+const GET_PRODUCTS = rest.get(`${PRODUCT_API}`, (req, res, ctx) => {
+  const page = req.url.searchParams.get('page');
+  return res(ctx.status(200), ctx.json(products[page]));
+});
+
+export const handlers = [GET_PRODUCTS];

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -5,7 +5,8 @@ import { products } from '@data';
 
 const GET_PRODUCTS = rest.get(`${PRODUCT_API}`, (req, res, ctx) => {
   const page = req.url.searchParams.get('page');
-  return res(ctx.status(200), ctx.json(products[page]));
+  const delay = page === '0' ? 2000 : 0;
+  return res(ctx.status(200), ctx.delay(delay), ctx.json(products[page]));
 });
 
 export const handlers = [GET_PRODUCTS];

--- a/src/pages/ProductSearch/ProductSearch.style.ts
+++ b/src/pages/ProductSearch/ProductSearch.style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;

--- a/src/pages/ProductSearch/index.tsx
+++ b/src/pages/ProductSearch/index.tsx
@@ -1,12 +1,13 @@
 import Header from '@components/Header';
 import ProductList from '@components/ProductList';
+import * as S from '@pages/ProductSearch/ProductSearch.style';
 
 const ProductSearch = () => {
   return (
-    <>
+    <S.Container>
       <Header />
       <ProductList />
-    </>
+    </S.Container>
   );
 };
 

--- a/src/query/product.ts
+++ b/src/query/product.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { useInfiniteQuery } from 'react-query';
+
+import { PRODUCT_API } from '@constants';
+import { ProductType } from '@data/products';
+
+interface FetchProductPropsType {
+  pageParam?: number;
+}
+
+export interface FetchProductsReturnType {
+  list: ProductType[];
+  isLast: boolean;
+  nextPage: number;
+}
+
+export const fetchProducts = async ({
+  pageParam = 0,
+}: FetchProductPropsType): Promise<FetchProductsReturnType> => {
+  const response = await axios.get(`${PRODUCT_API}`, {
+    params: {
+      page: pageParam,
+    },
+  });
+
+  return { list: response.data.list, isLast: response.data.isLast, nextPage: pageParam + 1 };
+};
+
+export const useProductQuery = () =>
+  useInfiniteQuery(['products'], fetchProducts, {
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.isLast) return lastPage.nextPage;
+      return undefined;
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });


### PR DESCRIPTION
## 📃 Description

리액트 쿼리와 intersection observer를 사용해 무한 스크롤을 구현했다.
리액트 쿼리의 특성상 데이터를 추가로 요청하면 데이터를 가져오는 동안 이전의 데이터를 계속 보여주다가 데이터를 받아오면 새로운 데이터를 보여주기 때문에, 로딩 스피너는 처음 데이터를 요청할 때만 보여주도록 했다.
intersection observer를 사용해 상품 리스트의 가장 마지막 항목을 구독하도록 하고, 마지막 항목이 0.5 이상 화면에 보여지면 다음 데이터를 fetch하도록 했다. observer 로직은 커스텀 훅으로 분리해주었다.

## 📸 Screenshot

![무한 스크롤](https://user-images.githubusercontent.com/62706988/179388503-14f51ae1-75f8-4f62-acce-0354ed9bc7ea.gif)
